### PR TITLE
Removed un-needed admin early return.

### DIFF
--- a/generators/app/templates/src/_Plugin.php
+++ b/generators/app/templates/src/_Plugin.php
@@ -32,9 +32,6 @@ class Plugin {
    * @implements init
    */
   public static function init() {
-    if (is_admin()) {
-      return;
-    }
   }
 
   /**


### PR DESCRIPTION
Follow up from https://github.com/netzstrategen/wordpress-shop-standards-notices/pull/5